### PR TITLE
WIP: Added experimental support for JIT classes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
+  - conda update numba # to get support for JIT classes
   # Useful for debugging any issues with conda
   - conda info -a
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,10 @@ install:
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
-  - conda update numba # to get support for JIT classes
   # Useful for debugging any issues with conda
   - conda info -a
 
-  - deps='pip nose numba numpy pandas cython scipy'
+  - deps='pip nose numba=0.23 numpy pandas cython scipy'
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION $deps
   - source activate test-environment
   - python setup.py install

--- a/interpolation/splines/filter_cubic.py
+++ b/interpolation/splines/filter_cubic.py
@@ -195,7 +195,6 @@ def filter_coeffs_4d(dinv, data):
 
     return coefs
 
-
 def filter_coeffs(smin, smax, orders, data):
     smin = np.array(smin, dtype=float)
     smax = np.array(smax, dtype=float)
@@ -212,7 +211,7 @@ def filter_mcoeffs(smin, smax, orders, data):
         coefs[...,i] = filter_coeffs(smin, smax, orders, data[..., i])
     return coefs
 
-
+@njit
 def filter_data(dinv, data):
     if len(dinv) == 1:
         return filter_coeffs_1d(dinv, data)

--- a/misc/try_jitclass.py
+++ b/misc/try_jitclass.py
@@ -1,0 +1,119 @@
+import numpy as np
+from interpolation.splines.filter_cubic import filter_coeffs_3d
+from interpolation.splines.eval_cubic import eval_cubic_spline_3
+from numba import jitclass, njit, float64, int64
+from collections import OrderedDict
+from numpy import array
+
+
+spec = OrderedDict()
+spec['a'] = float64[:]
+spec['b'] = float64[:]
+spec['orders'] = int64[:]
+spec['d'] = int64
+spec['coeffs'] = float64[:,:,:]
+
+@jitclass(spec)
+class Spline3D:
+
+    # a = None
+    # b = None
+    # orders = None
+    # d = None
+    # __coeffs__ = None
+
+    def __init__(self,a,b,orders,values):
+
+        self.a = a
+        self.b = b
+        self.orders = orders
+        dinv = (self.a - self.b) / self.orders
+        self.coeffs = filter_coeffs_3d(dinv,values)
+
+    def evaluate(self, point):
+        return eval_cubic_spline_3(self.a, self.b, self.orders, self.coeffs, point)
+
+
+a = np.array([0.0,0.0, 0.0])
+b = np.array([1.0,1.0,1.0])
+orders = np.array([50,50,50])
+values = np.random.random(orders)
+
+sp = Spline3D(a,b,orders,values)
+point = np.array([0.5,0.5, 0.5])
+res = sp.evaluate(point)
+
+
+# test performances on many points vs. "low-level" routines
+N = 10**6
+points = np.random.random( (N,3) )
+coeffs = sp.coeffs
+
+
+@njit
+def repeat_eval(sp, points, out):
+    N = points.shape[0]
+    vals = np.zeros(3)
+    for n in range(N):
+        pp = points[n,:]
+        out[n] = sp.evaluate( pp )
+    return vals
+
+@njit
+def repeat_eval_noclass(a,b,orders,coeffs, points,out):
+    N = points.shape[0]
+    vals = np.zeros(3)
+    for n in range(N):
+        pp = points[n,:]
+        out[n] = eval_cubic_spline_3(a, b, orders, coeffs, pp)
+    return vals
+
+
+
+out = np.zeros(N)
+
+repeat_eval(sp, points, out) # warmup
+repeat_eval_noclass(a, b, orders, coeffs, points,out)
+
+
+import time
+t1 = time.time()
+tot = repeat_eval(sp, points,out)
+t2 = time.time()
+print("JIT class (repeated call): {}".format(t2-t1))
+
+
+
+import time
+t1 = time.time()
+tot = repeat_eval_noclass(a, b, orders, coeffs, points,out)
+t2 = time.time()
+print("No class (repeated call): {}".format(t2-t1))
+
+
+
+
+# optimized call:
+from interpolation.splines.eval_cubic import vec_eval_cubic_spline_3
+out2 = np.zeros(N)
+# warmup
+vec_eval_cubic_spline_3(sp.a, sp.b, sp.orders, sp.coeffs, points, out2)
+t1 = time.time()
+vec_eval_cubic_spline_3(a, b, orders, coeffs, points, out2)
+t2 = time.time()
+print("Vectorized version: {}".format(t2-t1))
+
+
+# compare with scipy (linear)
+# probably not the best way to use it !
+from scipy.interpolate import RegularGridInterpolator
+
+pp = [np.linspace(a[i],b[i],orders[i]) for i in range(3)]
+regint = RegularGridInterpolator(pp, values)
+t1 = time.time()
+out_scipy = regint(points)
+t2 = time.time()
+
+print("Scipy (linear): {}".format(t2-t1))
+
+assert(abs(out-out2).max()<1e-10)


### PR DESCRIPTION
The file `misc/try_jit_classes` has one example of a spline object using numba's jit classes. 
sp = Spline3D(a,b,orders,values)

Current limitations:
- uses .evaluate() method instead of more natural **call**
- no type check
- works only for 3D. Is it possible to create an object that would work in any dimension ?

As for the performance aspect (which can still improve), it is not bad at all. On a 50x50x50 grid evaluating on 10^6 points:

```
JIT class (repeated call): 0.309826135635376         # repeated calls to JIT class
No class (repeated call): 0.23068761825561523     # direct repeated calls to interp. routine
Vectorized version: 0.10867524147033691             # vectorized function (with no memory allocation)
Scipy (linear): 0.692845344543457                          # (!?? is it the right way to proceed ?)
```
