### PR TITLE
FIX: derivatives of SmolyakInterp.

### DIFF
--- a/interpolation/smolyak/interp.py
+++ b/interpolation/smolyak/interp.py
@@ -106,7 +106,9 @@ class SmolyakInterp(object):
 
             if interp:
                 rets.append(vals)
-            rets.append(sg.dom2cube(d_vals))
+
+            radii = 2/(sg.ub - sg.lb)
+            rets.append( d_vals*radii[None,:] )
 
         elif not deriv and interp:  # No derivs in build_B. Just do vals
             new_B = build_B(d, sg.mu, trans_points, sg.pinds)
@@ -121,7 +123,8 @@ class SmolyakInterp(object):
         if deriv_X:
             if not interp and not deriv and not deriv_th:
                 new_B = build_B(d, sg.mu, trans_points, sg.pinds)
-            d_X = la.solve(sg.B_U, la.solve(sg.B_L, new_B.T))
+            d_X = la.solve(sg.B_L.T, la.solve(sg.B_U.T, new_B.T)).T
+            # assert(abs( new_B @ la.inv(sg.B) - d_X).max() < 1e-10)
             rets.append(d_X)
 
         if len(rets) == 1:

--- a/interpolation/smolyak/tests/test_derivatives.py
+++ b/interpolation/smolyak/tests/test_derivatives.py
@@ -1,0 +1,72 @@
+def test_derivatives():
+
+    from ..interp import SmolyakInterp
+    from ..grid import SmolyakGrid
+
+
+    d = 5
+    N = 100
+    mu = 2
+    f = lambda x: (x).sum(axis=1)
+
+    import numpy.random
+
+    ub = numpy.random.random(d) + 6
+    lb = numpy.random.random(d) - 5
+    sg = SmolyakGrid(d, mu, lb=lb, ub=ub)
+
+    values = f(sg.grid)
+    si = SmolyakInterp(sg, values)
+    gg = numpy.random.random((N,d))
+
+    res, res_s, res_c, res_x = si.interpolate(gg, deriv=True, deriv_th=True, deriv_X=True)
+
+    T = sg.grid.shape[0]
+
+    assert(res.shape == (N,))
+    assert(res_s.shape == (N,d))
+    assert(res_c.shape == (N,T))
+    assert(res_x.shape == (N,T))
+
+    # res_s should be identically 1
+    assert( abs(res_s-1.0).max()<1e-8 )
+
+    epsilon = 1e-6
+
+    # Test derivatives w.r.t. values
+
+    si2 = SmolyakInterp(sg, values)
+
+    def ff(y):
+        x = y.reshape(values.shape)
+        si2.update_theta(x)
+        return si2.interpolate(gg).ravel()
+
+    y0 = values.ravel()
+    r0 = ff(y0)
+    jac = numpy.zeros((len(r0),len(y0)))
+    for n in range(len(y0)):
+        yi = y0.copy()
+        yi[n] += epsilon
+        jac[:,n] = (ff(yi)-r0)/epsilon
+    jac = jac.reshape((N,T))
+    assert( abs(jac-res_x).max() < 1e-7 )
+    # note that accuracy of either numerical or direct computation is not very accurate
+
+
+    # Test derivatives w.r.t. coefficients
+
+    theta_0 = si.theta.copy()
+    def ff_c(y_c):
+        si2.theta = y_c.reshape(theta_0.shape)
+        return si2.interpolate(gg).ravel()
+
+    r0 = ff_c(theta_0)
+    jac = numpy.zeros((len(r0),len(theta_0)))
+    for n in range(len(y0)):
+        ti = theta_0.copy()
+        ti[n] += epsilon
+        jac[:,n] = (ff_c(ti)-r0)/epsilon
+    jac = jac.reshape((N,T))
+
+    assert( abs(jac-res_c).max() < 1e-7 )


### PR DESCRIPTION
@cc7768 , @spencerlyon2 : I found two bugs in the evaluation of the derivatives in `SmolyakInterp` when the grid domain is not `[-1,1]^d`. If you don't have time to have a look, I'll merge it later today.