### PR TITLE
Prepare world for Python 3.9

### DIFF
--- a/interpolation/splines/option_types.py
+++ b/interpolation/splines/option_types.py
@@ -1,6 +1,6 @@
 import numba
 
-from numba import jitclass
+# from numba import jitclass
 
 
 # Extrapolation types


### PR DESCRIPTION
The current development branch of numba for py39 does not provide `jitclass`: 
https://github.com/stuartarchibald/numba#branch=wip/py39_2

Lucky that we don't need it.