### PR TITLE
Add value tests for linear derivatives

### DIFF
--- a/interpolation/splines/__init__.py
+++ b/interpolation/splines/__init__.py
@@ -5,7 +5,7 @@ from .eval_splines import options, eval_linear, eval_cubic, eval_spline
 from .prefilter_cubic import filter_cubic, prefilter
 from .option_types import options as extrap_options
 
-
+import numba
 import numpy as np
 
 # dummy functions
@@ -23,7 +23,7 @@ def UCGrid(*args):
 def CGrid(*args):
     tt = numba.typeof((10.0, 1.0, 1))
     for a in args:
-        if isinstance(a, np.array):
+        if isinstance(a, np.ndarray):
             assert(a.ndim==1)
             assert(a.shape[0]>2)
         elif (numba.typeof(a) == tt):

--- a/interpolation/tests/test_derivs.py
+++ b/interpolation/tests/test_derivs.py
@@ -32,8 +32,6 @@ class Check1DDerivatives(unittest.TestCase):
             extrap_mode="linear",
         )
 
-        print(grad)
-
         # 0-order must be the function
         # 1-order must be the slope
         result = np.vstack(

--- a/interpolation/tests/test_derivs.py
+++ b/interpolation/tests/test_derivs.py
@@ -1,0 +1,49 @@
+import unittest
+from interpolation.splines import CGrid, eval_spline
+import numpy as np
+import numba
+
+
+class Check1DDerivatives(unittest.TestCase):
+    """ 
+    Checks derivatives in a 1D interpolator
+    """
+
+    def setUp(self):
+
+        pass
+
+    def test_linear(self):
+
+        # A linear function on a non-uniform grid
+        x = np.exp(np.linspace(0, 2, 6))
+        y0 = 2
+        slope = 1.0
+        y = y0 + slope * x
+
+        eval_points = np.array([1.5, 2.5, 3.5, 4.5])
+
+        grad = eval_spline(
+            CGrid(x),
+            y,
+            eval_points[..., None],
+            out=None,
+            order=1,
+            diff=str(((0,), (1,), (2,))),
+            extrap_mode="linear",
+        )
+
+        print(grad)
+
+        # 0-order must be the function
+        # 1-order must be the slope
+        # 2-order must be 0
+        result = np.vstack(
+            [
+                y0 + slope * eval_points,
+                np.ones_like(eval_points) * slope,
+                np.zeros_like(eval_points),
+            ]
+        ).T
+
+        self.assertTrue(np.allclose(grad, result))

--- a/interpolation/tests/test_derivs.py
+++ b/interpolation/tests/test_derivs.py
@@ -29,7 +29,7 @@ class Check1DDerivatives(unittest.TestCase):
             eval_points[..., None],
             out=None,
             order=1,
-            diff=str(((0,), (1,), (2,))),
+            diff=str(((0,), (1,))),
             extrap_mode="linear",
         )
 
@@ -37,13 +37,8 @@ class Check1DDerivatives(unittest.TestCase):
 
         # 0-order must be the function
         # 1-order must be the slope
-        # 2-order must be 0
         result = np.vstack(
-            [
-                y0 + slope * eval_points,
-                np.ones_like(eval_points) * slope,
-                np.zeros_like(eval_points),
-            ]
+            [y0 + slope * eval_points, np.ones_like(eval_points) * slope,]
         ).T
 
         self.assertTrue(np.allclose(grad, result))
@@ -62,19 +57,40 @@ class Check1DDerivatives(unittest.TestCase):
             eval_points[..., None],
             out=None,
             order=1,
-            diff=str(((0,), (1,), (2,))),
+            diff=str(((0,), (1,))),
             extrap_mode="linear",
         )
 
         # 0-order must be the function
-        # 1-order must be the + or - pi/2
-        # 2-order must be 0
+        # 1-order must be + or - pi/2
         result = np.vstack(
-            [
-                np.array([0, -1, 0, 1, 0]),
-                np.array([-1, -1, 1, 1, -1]) * 2 / np.pi,
-                np.array([0, 0, 0, 0, 0]),
-            ]
+            [np.array([0, -1, 0, 1, 0]), np.array([-1, -1, 1, 1, -1]) * 2 / np.pi,]
         ).T
 
         self.assertTrue(np.allclose(grad, result))
+
+    def test_nonlinear_approx(self):
+
+        # A non linear function on uniform grid
+        x = np.linspace(-10, 10, 10000)
+        y = np.power(x, 3)
+
+        eval_points = np.linspace(-5, 5, 10)
+
+        grad = eval_spline(
+            CGrid(x),
+            y,
+            eval_points[..., None],
+            out=None,
+            order=1,
+            diff=str(((0,), (1,))),
+            extrap_mode="linear",
+        )
+
+        # 0-order must be x^3
+        # 1-order must be close to 3x^2
+        result = np.vstack(
+            [np.power(eval_points, 3), np.power(eval_points, 2) * 3.0,]
+        ).T
+
+        self.assertTrue(np.allclose(grad, result, atol=0.02))

--- a/interpolation/tests/test_derivs.py
+++ b/interpolation/tests/test_derivs.py
@@ -94,3 +94,96 @@ class Check1DDerivatives(unittest.TestCase):
         ).T
 
         self.assertTrue(np.allclose(grad, result, atol=0.02))
+
+
+class Check2DDerivatives(unittest.TestCase):
+    """ 
+    Checks derivatives in a 2D interpolator
+    """
+
+    def setUp(self):
+
+        pass
+
+    def test_linear(self):
+
+        # A linear function on a non-uniform grid
+        x = np.exp(np.linspace(0, 2, 6))
+        y = np.power(np.linspace(0, 5, 10), 2)
+
+        inter = 1
+        slope_x = 2
+        slope_y = -3
+        z = inter + slope_x * x[..., None] + slope_y * y[None, ...]
+
+        # Evaluation points
+        n_eval = 15
+        eval_points = np.vstack(
+            [np.linspace(-20, 20, n_eval), np.linspace(5, -5, n_eval)]
+        ).T
+
+        # Get function and 1st derivatives
+        grad = eval_spline(
+            CGrid(x, y),
+            z,
+            eval_points,
+            out=None,
+            order=1,
+            diff=str(((0, 0), (1, 0), (0, 1), (1, 1))),
+            extrap_mode="linear",
+        )
+
+        # 0-order must be the function
+        # (1,0) must be x slope
+        # (0,1) must be y slope
+        # (1,1) must be 0
+        result = np.hstack(
+            [
+                inter + slope_x * eval_points[:, 0:1] + slope_y * eval_points[:, 1:2],
+                np.ones((n_eval, 1)) * slope_x,
+                np.ones((n_eval, 1)) * slope_y,
+                np.zeros((n_eval, 1)),
+            ]
+        )
+
+        self.assertTrue(np.allclose(grad, result))
+
+    def test_nonlinear_approx(self):
+
+        # A non linear function on uniform grid
+        n_grid = 100
+        x = np.linspace(1, 5, n_grid)
+        y = np.linspace(1, 5, n_grid)
+        z = np.sin(x[..., None]) * np.log(y[None, ...])
+
+        # Evaluation points
+        n_eval = 15
+        eval_points = np.vstack(
+            [np.linspace(2, 4, n_eval), np.linspace(4, 2, n_eval)]
+        ).T
+
+        # Get function and 1st derivatives
+        grad = eval_spline(
+            CGrid(x, y),
+            z,
+            eval_points,
+            out=None,
+            order=1,
+            diff=str(((0, 0), (1, 0), (0, 1), (1, 1))),
+            extrap_mode="linear",
+        )
+
+        # 0-order must be sin(x)*ln(y)
+        # (1,0) must be cos(x) * ln(y)
+        # (0,1) must be sin(x) / y
+        # (1,1) must be cos(x) / y
+        result = np.hstack(
+            [
+                np.sin(eval_points[:, 0:1]) * np.log(eval_points[:, 1:2]),
+                np.cos(eval_points[:, 0:1]) * np.log(eval_points[:, 1:2]),
+                np.sin(eval_points[:, 0:1]) * (1 / eval_points[:, 1:2]),
+                np.cos(eval_points[:, 0:1]) * (1 / eval_points[:, 1:2]),
+            ]
+        )
+
+        self.assertTrue(np.allclose(grad, result, atol=0.02))

--- a/interpolation/tests/test_derivs.py
+++ b/interpolation/tests/test_derivs.py
@@ -47,3 +47,34 @@ class Check1DDerivatives(unittest.TestCase):
         ).T
 
         self.assertTrue(np.allclose(grad, result))
+
+    def test_nonlinear(self):
+
+        # A non linear function on uniform grid
+        x = np.linspace(-10, 10, 21) * (1 / 2) * np.pi
+        y = np.sin(x)
+
+        eval_points = np.array([-1, -0.5, 0, 0.5, 1]) * np.pi
+
+        grad = eval_spline(
+            CGrid(x),
+            y,
+            eval_points[..., None],
+            out=None,
+            order=1,
+            diff=str(((0,), (1,), (2,))),
+            extrap_mode="linear",
+        )
+
+        # 0-order must be the function
+        # 1-order must be the + or - pi/2
+        # 2-order must be 0
+        result = np.vstack(
+            [
+                np.array([0, -1, 0, 1, 0]),
+                np.array([-1, -1, 1, 1, -1]) * 2 / np.pi,
+                np.array([0, 0, 0, 0, 0]),
+            ]
+        ).T
+
+        self.assertTrue(np.allclose(grad, result))

--- a/interpolation/tests/test_derivs.py
+++ b/interpolation/tests/test_derivs.py
@@ -1,7 +1,6 @@
 import unittest
 from interpolation.splines import CGrid, eval_spline
 import numpy as np
-import numba
 
 
 class Check1DDerivatives(unittest.TestCase):


### PR DESCRIPTION
This PR adds tests that check that the derivatives produced by `eval_spline` are correct. It contains tests only for linear interpolators (`order==1`) of up to two dimensions, and checks only first order derivatives.

I believe current tests of the derivative functionality check only that the code runs and not for correct outputs.

Tagging @llorracc and @aniecon since they were part of the discussion in #94 . 