### PR TITLE
Apply `@njit` to `interp` and `mlinterp`

### DIFF
--- a/interpolation/multilinear/mlinterp.py
+++ b/interpolation/multilinear/mlinterp.py
@@ -49,7 +49,7 @@ def _mlinterp(grid, c, u):
 def ol_mlinterp(grid, c, u):
     if isinstance(u, UniTuple):
 
-        def mlininterp(grid: Tuple, c: Array, u: Tuple) -> float:
+        def mlininterp(grid, c, u):
             # get indices and barycentric coordinates
             tmp = fmap(get_index, grid, u)
             indices, barycenters = funzip(tmp)
@@ -59,7 +59,7 @@ def ol_mlinterp(grid, c, u):
 
     elif isinstance(u, Array) and u.ndim == 2:
 
-        def mlininterp(grid: Tuple, c: Array, u: Array) -> float:
+        def mlininterp(grid, c, u):
             N = u.shape[0]
             res = np.zeros(N)
             for n in range(N):

--- a/interpolation/multilinear/mlinterp.py
+++ b/interpolation/multilinear/mlinterp.py
@@ -228,9 +228,7 @@ def _interp(*args):
 
 @overload(_interp)
 def ol_interp(*args):
-    aa = args[0].types
-
-    it = detect_types(aa)
+    it = detect_types(args)
     if it.d == 1 and it.eval == "point":
         it = itt(it.d, it.values, "cartesian")
     source = make_mlinterp(it, "__mlinterp")

--- a/interpolation/multilinear/mlinterp.py
+++ b/interpolation/multilinear/mlinterp.py
@@ -41,11 +41,11 @@ import numpy as np
 # logic of multilinear interpolation
 
 
-def mlinterp(grid, c, u):
+def _mlinterp(grid, c, u):
     pass
 
 
-@overload(mlinterp)
+@overload(_mlinterp)
 def ol_mlinterp(grid, c, u):
     if isinstance(u, UniTuple):
 
@@ -74,6 +74,11 @@ def ol_mlinterp(grid, c, u):
     else:
         mlininterp = None
     return mlininterp
+
+
+@njit
+def mlinterp(grid, c, u):
+    return _mlinterp(grid, c, u)
 
 
 ### The rest of this file constrcts function `interp`
@@ -217,11 +222,11 @@ def {funname}(*args):
         return source
 
 
-def interp(*args):
+def _interp(*args):
     pass
 
 
-@overload(interp)
+@overload(_interp)
 def ol_interp(*args):
     aa = args[0].types
 
@@ -235,3 +240,8 @@ def ol_interp(*args):
     code = compile(tree, "<string>", "exec")
     eval(code, globals())
     return __mlinterp
+
+
+@njit
+def interp(*args):
+    return _interp(*args)

--- a/interpolation/multilinear/tests/test_multilinear.py
+++ b/interpolation/multilinear/tests/test_multilinear.py
@@ -115,7 +115,10 @@ def test_mlinterp():
     pp = np.random.random((2000, 2))
 
     res0 = mlinterp((x1, x2), y, pp)
+    assert res0 is not None
+
     res0 = mlinterp((x1, x2), y, (0.1, 0.2))
+    assert res0 is not None
 
 
 def test_multilinear():
@@ -124,6 +127,8 @@ def test_multilinear():
     for t in tests:
         tt = [typeof(e) for e in t]
         rr = interp(*t)
+
+        assert rr is not None
 
         try:
             print(f"{tt}: {rr.shape}")


### PR DESCRIPTION
`interp` and `mlinterp` now return something other than `None`.

I do not know what this line was doing: https://github.com/EconForge/interpolation.py/blob/705cbce6c37f8605e00d503a4d7ff9516512ce78/interpolation/multilinear/mlinterp.py#L226

See the change in 7003f0fd625dab76364091b788ef9b095ad5a0cd