### PR TITLE
Use `prefer_literal` flag in `overload`

### DIFF
--- a/interpolation/splines/eval_splines.py
+++ b/interpolation/splines/eval_splines.py
@@ -95,7 +95,7 @@ def _eval_spline():
     pass
 
 
-@overload(_eval_spline)
+@overload(_eval_spline, prefer_literal=True)
 def __eval_spline(grid, C, points, out=None, k=1, diff="None", extrap_mode="linear"):
     kk = (k).literal_value
     diffs = (diff).literal_value


### PR DESCRIPTION
Fixes #115.

With this diff and `numba=0.60`, all the `splines` tests are working fine:
```bash
% pytest interpolation/splines/tests
============================= test session starts ==============================
platform darwin -- Python 3.10.12, pytest-8.1.0, pluggy-1.4.0
rootdir: /Users/kpl/repos/interpolation.py
configfile: pyproject.toml
plugins: anyio-4.0.0
collected 13 items                                                             

interpolation/splines/tests/test_cubic_splines.py ....                   [ 30%]
interpolation/splines/tests/test_derivatives.py .                        [ 38%]
interpolation/splines/tests/test_eval_splines.py .                       [ 46%]
interpolation/splines/tests/test_fortran_order.py ..                     [ 61%]
interpolation/splines/tests/test_hermite_splines.py .                    [ 69%]
interpolation/splines/tests/test_multilinear_extrap.py .                 [ 76%]
interpolation/splines/tests/test_object_api.py .                         [ 84%]
interpolation/splines/tests/test_readonly.py ..                          [100%]

============================= 13 passed in 23.71s ==============================

```

cc @albop 